### PR TITLE
[feat] 회원가입 페이지 구현 

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -13,7 +13,8 @@ import LoginPage from './pages/Login/LoginPage.jsx';
 import FindAccountPage from './pages/Login/FindAccountPage.jsx';
 import FindIdPage from './pages/Login/FindIdPage.jsx';
 import ResetPasswordPage from './pages/Login/ResetPasswordPage.jsx';
-
+import SignupPage from './pages/Signup/SignupPage.jsx';
+import SignupCompletePage from './pages/Signup/SignupCompletePage.jsx';
 
 const AppRoutes = () => {
   return (
@@ -28,6 +29,8 @@ const AppRoutes = () => {
         <Route path="/find-account" element={<FindAccountPage />} />
         <Route path="/find-id" element={<FindIdPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/signup-complete" element={<SignupCompletePage />} />
       </Routes>
       <Footer />
     </Router>

--- a/src/components/ui/loginPage/resetPasswordApi.ts
+++ b/src/components/ui/loginPage/resetPasswordApi.ts
@@ -1,17 +1,106 @@
-export async function resetPasswordRequest({ loginId, email }) {
+// components/ui/resetPasswordPage/resetPasswordApi.ts
+
+export interface ResetPasswordRequest {
+    loginId: string;
+    email: string;
+}
+
+export interface ResetPasswordResponse {
+    success: boolean;
+    message: string;
+    userVerified?: boolean;  // 사용자 검증 결과
+    emailSent?: boolean;     // 이메일 전송 결과
+}
+
+/**
+ * 비밀번호 재설정 요청 함수
+ * @param loginId - 사용자 로그인 ID
+ * @param email - 사용자 이메일
+ * @returns 서버 응답 데이터, 실패 시 null
+ */
+export async function resetPasswordRequest({
+    loginId,
+    email,
+}: ResetPasswordRequest): Promise<ResetPasswordResponse | null> {
     try {
-      const response = await fetch('http://localhost:8080/users/reset-password', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          accept: '*/*',
-        },
-        body: JSON.stringify({ loginId, email }),
-      });
-  
-      return response.ok;
+        console.log('[비밀번호 재설정] 요청 시작:', { loginId, email });
+
+        // 비밀번호 재설정 요청 (단일 엔드포인트로 변경)
+        const response = await fetch('http://localhost:8080/users/reset-password', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({ 
+                loginId: loginId.trim(),  // 공백 제거
+                email: email.trim()       // 공백 제거
+            }),
+        });
+
+        console.log('[비밀번호 재설정] HTTP 응답:', {
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries())
+        });
+
+        // 응답 텍스트 먼저 받기
+        const responseText = await response.text();
+        console.log('[비밀번호 재설정] 응답 텍스트:', responseText);
+
+        // 응답이 JSON이 아닌 경우 처리
+        let data;
+        try {
+            data = JSON.parse(responseText);
+        } catch (e) {
+            console.error('[비밀번호 재설정] JSON 파싱 오류:', e);
+            return {
+                success: false,
+                message: '서버 응답을 처리할 수 없습니다.',
+                userVerified: false,
+                emailSent: false
+            };
+        }
+
+        console.log('[비밀번호 재설정] 파싱된 응답:', data);
+
+        // 서버 응답 형식 검증
+        if (!data || typeof data !== 'object') {
+            console.error('[비밀번호 재설정] 잘못된 응답 형식:', data);
+            return {
+                success: false,
+                message: '서버 응답 형식이 올바르지 않습니다.',
+                userVerified: false,
+                emailSent: false
+            };
+        }
+
+        // 성공 응답
+        if (response.ok && data.success) {
+            return {
+                success: true,
+                message: data.message || '임시 비밀번호가 이메일로 전송되었습니다.',
+                userVerified: true,
+                emailSent: true
+            };
+        }
+
+        // 실패 응답
+        return {
+            success: false,
+            message: data.message || '비밀번호 재설정에 실패했습니다.',
+            userVerified: false,
+            emailSent: false
+        };
+
     } catch (error) {
-      throw new Error('API error');
+        console.error('[비밀번호 재설정] API 오류:', error);
+        return {
+            success: false,
+            message: '서버와의 통신 중 오류가 발생했습니다.',
+            userVerified: false,
+            emailSent: false
+        };
     }
-  }
+}
   

--- a/src/components/ui/signupPage/userCheckApi.ts
+++ b/src/components/ui/signupPage/userCheckApi.ts
@@ -1,0 +1,160 @@
+// src/api/userCheckApi.ts
+
+const API_BASE_URL = 'http://localhost:8080';
+
+const fetchWithConfig = async (url: string, options: RequestInit = {}) => {
+  const defaultOptions: RequestInit = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    mode: 'cors',
+    credentials: 'include',
+    ...options,
+  };
+
+  try {
+    const response = await fetch(url, defaultOptions);
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
+    }
+    return response;
+  } catch (error) {
+    console.error('Fetch error:', error);
+    throw error;
+  }
+};
+
+export async function checkLoginId(loginId: string): Promise<boolean> {
+    try {
+      const response = await fetchWithConfig(`${API_BASE_URL}/users/check-loginId?loginId=${encodeURIComponent(loginId)}`, {
+        method: 'GET',
+        headers: {
+          'Origin': 'http://localhost:3000'
+        }
+      });
+      
+      if (response.status === 200) {
+        return true;
+      } else if (response.status === 409) {
+        return false;
+      }
+      return false;
+    } catch (err) {
+      console.error('Login ID check failed:', err);
+      throw err;
+    }
+}
+  
+export async function checkEmail(email: string): Promise<boolean> {
+    try {
+      const response = await fetchWithConfig(`${API_BASE_URL}/users/check-email?email=${encodeURIComponent(email)}`, {
+        method: 'GET',
+        headers: {
+          'Origin': 'http://localhost:3000'
+        }
+      });
+      
+      if (response.status === 200) {
+        return true;
+      } else if (response.status === 409) {
+        return false;
+      }
+      return false;
+    } catch (err) {
+      console.error('Email check failed:', err);
+      throw err;
+    }
+}
+  
+export async function checkNickname(nickname: string): Promise<boolean> {
+    try {
+      const response = await fetchWithConfig(`${API_BASE_URL}/users/check-nickname?nickname=${encodeURIComponent(nickname)}`, {
+        method: 'GET',
+        headers: {
+          'Origin': 'http://localhost:3000'
+        }
+      });
+      
+      if (response.status === 200) {
+        return true;
+      } else if (response.status === 409) {
+        return false;
+      }
+      return false;
+    } catch (err) {
+      console.error('Nickname check failed:', err);
+      throw err;
+    }
+}
+  
+export async function sendEmailCode(email: string): Promise<boolean> {
+    try {
+      const response = await fetch('http://localhost:8080/email-verification', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          accept: '*/*',
+        },
+        body: JSON.stringify({ email }),
+      });
+  
+      return response.ok; // 200이면 true
+    } catch (err) {
+      console.error('Error sending email code:', err);
+      return false;
+    }
+  }
+  
+  export async function verifyEmailCode(email: string, code: string): Promise<boolean> {
+    try {
+      const response = await fetch('http://localhost:8080/email-verification/verify', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          accept: '*/*',
+        },
+        body: JSON.stringify({ email, code }),
+      });
+  
+      return response.ok; // 인증 성공 시 true
+    } catch (err) {
+      console.error('Error verifying email code:', err);
+      return false;
+    }
+  }
+  
+export async function signupUser(userData: {
+    loginId: string;
+    password: string;
+    email: string;
+    nickname: string;
+}): Promise<boolean> {
+    try {
+        const response = await fetch('http://localhost:8080/users/signup', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            },
+            body: JSON.stringify({
+                loginId: userData.loginId,
+                password: userData.password,
+                email: userData.email,
+                nickname: userData.nickname
+            })
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json().catch(() => ({}));
+            console.error('Signup failed:', errorData);
+            throw new Error(errorData.message || '회원가입 처리 중 오류가 발생했습니다.');
+        }
+
+        return true;
+    } catch (err) {
+        console.error('Signup error details:', err);
+        throw err;
+    }
+}  

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2,61 +2,139 @@
   "language.select": "Sprache auswählen",
   "login": "Anmelden",
   "signup": "Registrieren",
-  "search": "Suche",
+  "search": "Suchen",
+  "logout": "Abmelden",
   "currentLanguage": "Aktuelle Sprache",
   "close": "Schließen",
   "tteokbokki": "Tteokbokki",
-  "kpop": "K-Pop",
+  "kpop": "K-pop",
   "bts": "BTS",
   "bibimbap": "Bibimbap",
   "amusementpark": "Freizeitpark",
   "cherryblossom": "Kirschblüte",
   "movie": "Film",
-  "searchPrompt": "Bitte geben Sie ein Suchwort ein.",
+  "searchPrompt": "Suchbegriff eingeben",
 
   "loginPage": {
-    "title": "Anmeldung",
+    "title": "Anmelden",
     "idPlaceholder": "Benutzername",
     "pwPlaceholder": "Passwort",
     "rememberMe": "Angemeldet bleiben",
-    "findAccount": "Benutzername/Passwort vergessen?",
-    "loginButton": "Einloggen",
+    "findAccount": "Benutzername/Passwort finden",
+    "loginButton": "Anmelden",
     "signupButton": "Registrieren",
-    "errorEmpty": "Bitte geben Sie Benutzername und Passwort ein.",
-    "errorInvalid": "Anmeldung fehlgeschlagen. Bitte überprüfen Sie Ihre Angaben.",
+    "errorEmpty": "Bitte geben Sie Benutzername und Passwort ein",
+    "errorInvalid": "Anmeldung fehlgeschlagen. Überprüfen Sie Benutzername und Passwort",
     "success": "Willkommen, {{nickname}}!"
   },
 
   "findAccount": {
-    "title": "Benutzer-ID finden / Passwort zurücksetzen",
-    "idTitle": "Benutzer-ID finden",
-    "idDesc": "Finden Sie Ihre Benutzer-ID per E-Mail-Verifizierung.",
-    "idButton": "ID finden",
+    "title": "Benutzername/Passwort finden",
+    "idTitle": "Benutzername finden",
+    "idDesc": "Finden Sie Ihren Benutzernamen per E-Mail-Verifizierung",
+    "idButton": "Benutzername finden",
     "pwTitle": "Passwort zurücksetzen",
-    "pwDesc": "Geben Sie Ihre ID und E-Mail-Adresse ein, um Ihr Passwort zurückzusetzen.",
-    "pwButton": "Passwort zurücksetzen"
+    "pwDesc": "Setzen Sie Ihr Passwort zurück, indem Sie Benutzername und E-Mail eingeben",
+    "pwButton": "Zurücksetzen"
   },
 
   "findId": {
-    "title": "Benutzer-ID finden",
-    "emailPlaceholder": "Bitte geben Sie Ihre E-Mail-Adresse ein.",
-    "findButton": "ID finden",
-    "success": "Ihre ID wurde an die eingegebene E-Mail-Adresse gesendet.",
-    "goLogin": "Zum Login",
-    "errorEmpty": "Bitte geben Sie Ihre E-Mail-Adresse ein.",
-    "errorNotFound": "Keine ID unter dieser E-Mail-Adresse gefunden.",
-    "errorServer": "Ein Serverfehler ist aufgetreten. Bitte versuchen Sie es erneut."
+    "title": "Benutzername finden",
+    "emailPlaceholder": "E-Mail eingeben",
+    "findButton": "Benutzername finden",
+    "success": "Ihr Benutzername wurde an Ihre E-Mail gesendet",
+    "goLogin": "Zur Anmeldung",
+    "errorEmpty": "Bitte geben Sie Ihre E-Mail ein",
+    "errorNotFound": "Kein Benutzername für diese E-Mail gefunden",
+    "errorServer": "Serverfehler aufgetreten. Bitte versuchen Sie es später erneut"
   },
 
   "resetPassword": {
     "title": "Passwort zurücksetzen",
-    "idPlaceholder": "Geben Sie Ihre Benutzer-ID ein.",
-    "emailPlaceholder": "Geben Sie Ihre E-Mail-Adresse ein.",
-    "resetButton": "Passwort zurücksetzen",
-    "success": "Ein temporäres Passwort wurde an Ihre E-Mail gesendet. Bitte ändern Sie es nach dem Login.",
-    "goLogin": "Zum Login",
-    "errorEmpty": "Bitte geben Sie sowohl ID als auch E-Mail ein.",
-    "errorNotFound": "Keine übereinstimmenden Informationen gefunden.",
-    "errorServer": "Ein Serverfehler ist aufgetreten. Bitte versuchen Sie es erneut."
+    "idPlaceholder": "Benutzername eingeben",
+    "emailPlaceholder": "E-Mail eingeben",
+    "resetButton": "Zurücksetzen",
+    "submitting": "Wird verarbeitet...",
+    "success": "Ein temporäres Passwort wurde an Ihre E-Mail gesendet. Bitte ändern Sie es nach der Anmeldung",
+    "goLogin": "Zur Anmeldung",
+    "errorEmpty": "Bitte geben Sie Benutzername und E-Mail ein",
+    "errorInvalidId": "Der Benutzername muss 4-20 alphanumerische Zeichen enthalten",
+    "errorInvalidEmail": "Ungültiges E-Mail-Format",
+    "errorNotFound": "Kein Benutzer mit den angegebenen Daten gefunden",
+    "errorEmailSend": "E-Mail konnte nicht gesendet werden. Bitte versuchen Sie es später erneut",
+    "errorServer": "Serverfehler aufgetreten. Bitte versuchen Sie es später erneut"
+  },
+
+  "signupPage": {
+    "title": "Registrierung",
+    "id": "Benutzername",
+    "idPlaceholder": "Benutzername eingeben",
+    "email": "E-Mail",
+    "emailPlaceholder": "E-Mail eingeben",
+    "password": "Passwort",
+    "passwordPlaceholder": "Passwort eingeben",
+    "confirmPassword": "Passwort bestätigen",
+    "confirmPasswordPlaceholder": "Passwort erneut eingeben",
+    "nickname": "Nickname",
+    "nicknamePlaceholder": "Nickname eingeben",
+    "checkDuplicate": "Überprüfen",
+    "getVerificationCode": "Code anfordern",
+    "verifyEmail": "E-Mail-Verifizierung",
+    "verifyEmailDesc": "Bitte geben Sie den an Ihre E-Mail gesendeten Verifizierungscode ein",
+    "verificationCodePlaceholder": "Verifizierungscode eingeben",
+    "cancel": "Abbrechen",
+    "confirm": "Bestätigen",
+    "signupButton": "Registrieren",
+    
+    "errorEmpty": {
+      "id": "Bitte geben Sie einen Benutzernamen ein",
+      "email": "Bitte geben Sie eine E-Mail ein",
+      "nickname": "Bitte geben Sie einen Nickname ein"
+    },
+    "errorInvalid": {
+      "id": "Der Benutzername darf keine Leerzeichen enthalten",
+      "nickname": "Der Nickname darf keine Leerzeichen enthalten",
+      "email": "Ungültiges E-Mail-Format"
+    },
+    "errorDuplicate": {
+      "id": "Dieser Benutzername ist bereits vergeben",
+      "email": "Diese E-Mail ist bereits registriert",
+      "nickname": "Dieser Nickname ist bereits vergeben"
+    },
+    "success": {
+      "id": "Dieser Benutzername ist verfügbar",
+      "email": "Diese E-Mail ist verfügbar",
+      "nickname": "Dieser Nickname ist verfügbar",
+      "emailVerification": "E-Mail-Verifizierung abgeschlossen"
+    },
+    "passwordValidation": {
+      "valid": "Passwort ist gültig",
+      "invalid": "8-20 Zeichen, muss Buchstaben (mit Großbuchstaben) + Zahlen + Sonderzeichen (!@^*) enthalten, keine Leerzeichen/Koreanisch erlaubt",
+      "match": "Passwörter stimmen überein",
+      "mismatch": "Passwörter stimmen nicht überein"
+    },
+    "verification": {
+      "sendSuccess": "Verifizierungscode gesendet",
+      "sendError": "Fehler beim Senden des Codes",
+      "invalidCode": "Ungültiger Verifizierungscode",
+      "error": "Fehler bei der Verifizierung"
+    },
+    "submit": {
+      "missingItems": "Bitte vervollständigen Sie folgende Punkte:",
+      "idCheck": "Benutzername-Überprüfung",
+      "emailCheck": "E-Mail-Überprüfung",
+      "emailVerification": "E-Mail-Verifizierung",
+      "passwordCheck": "Passwortformat-Überprüfung",
+      "passwordMatch": "Passwort-Übereinstimmung",
+      "nicknameCheck": "Nickname-Überprüfung",
+      "success": "Registrierung abgeschlossen!",
+      "error": "Fehler bei der Registrierung. Bitte versuchen Sie es später erneut"
+    }
+  },
+
+  "signupComplete": {
+    "title": "WILLKOMMEN!",
+    "message": "Registrierung erfolgreich abgeschlossen",
+    "loginButton": "Anmelden"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,61 +3,139 @@
   "login": "Login",
   "signup": "Sign Up",
   "search": "Search",
+  "logout": "Logout",
   "currentLanguage": "Current Language",
   "close": "Close",
-  "searchPrompt": "Please enter a search term.",
+  "searchPrompt": "Enter search term",
   "tteokbokki": "Tteokbokki",
   "kpop": "K-pop",
   "bts": "BTS",
   "bibimbap": "Bibimbap",
-  "amusementpark": "amusementpark",
-  "cherryblossom": "cherryblossom",
-  "movie": "movie",
+  "amusementpark": "Amusement Park",
+  "cherryblossom": "Cherry Blossom",
+  "movie": "Movie",
 
   "loginPage": {
     "title": "Login",
-    "idPlaceholder": "Username",
+    "idPlaceholder": "ID",
     "pwPlaceholder": "Password",
-    "rememberMe": "Keep me logged in",
-    "findAccount": "Forgot ID or Password?",
-    "loginButton": "Log In",
+    "rememberMe": "Remember Me",
+    "findAccount": "Find ID/Password",
+    "loginButton": "Login",
     "signupButton": "Sign Up",
-    "errorEmpty": "Please enter both username and password.",
-    "errorInvalid": "Login failed. Please check your credentials.",
+    "errorEmpty": "Please enter both ID and password.",
+    "errorInvalid": "Login failed. Please check your ID and password.",
     "success": "Welcome, {{nickname}}!"
   },
 
   "findAccount": {
-    "title": "Find ID / Reset Password",
-    "idTitle": "Find Your ID",
-    "idDesc": "Find your ID via email verification.",
+    "title": "Find ID/Password",
+    "idTitle": "Find ID",
+    "idDesc": "Find your ID through email verification.",
     "idButton": "Find ID",
     "pwTitle": "Reset Password",
-    "pwDesc": "Enter your ID and email to reset your password.",
+    "pwDesc": "Reset your password by entering your ID and email.",
     "pwButton": "Reset Password"
   },
 
   "findId": {
     "title": "Find ID",
-    "emailPlaceholder": "Enter your email.",
+    "emailPlaceholder": "Enter your email",
     "findButton": "Find ID",
-    "success": "Your ID has been sent to the entered email.",
+    "success": "Your ID has been sent to your email.",
     "goLogin": "Go to Login",
     "errorEmpty": "Please enter your email.",
-    "errorNotFound": "No ID is registered with that email.",
-    "errorServer": "A server error occurred. Please try again."
+    "errorNotFound": "No ID found for this email.",
+    "errorServer": "Server error occurred. Please try again."
   },
 
   "resetPassword": {
     "title": "Reset Password",
-    "idPlaceholder": "Enter your ID.",
-    "emailPlaceholder": "Enter your email.",
+    "idPlaceholder": "Enter your ID",
+    "emailPlaceholder": "Enter your email",
     "resetButton": "Reset Password",
-    "success": "A temporary password has been sent to your email. Please change it after logging in.",
+    "submitting": "Processing...",
+    "success": "A temporary password has been sent to your email. Please change your password after logging in.",
     "goLogin": "Go to Login",
     "errorEmpty": "Please enter both ID and email.",
-    "errorNotFound": "No matching information found.",
-    "errorServer": "A server error occurred. Please try again."
+    "errorInvalidId": "ID must be 4-20 characters long with alphanumeric characters.",
+    "errorInvalidEmail": "Invalid email format.",
+    "errorNotFound": "No user found with the provided ID and email.",
+    "errorEmailSend": "Failed to send email. Please try again later.",
+    "errorServer": "Server error occurred. Please try again later."
+  },
+
+  "signupPage": {
+    "title": "Sign Up",
+    "id": "ID",
+    "idPlaceholder": "Enter your ID",
+    "email": "Email",
+    "emailPlaceholder": "Enter your email",
+    "password": "Password",
+    "passwordPlaceholder": "Enter your password",
+    "confirmPassword": "Confirm Password",
+    "confirmPasswordPlaceholder": "Enter your password again",
+    "nickname": "Nickname",
+    "nicknamePlaceholder": "Enter your nickname",
+    "checkDuplicate": "Check Duplicate",
+    "getVerificationCode": "Get Verification Code",
+    "verifyEmail": "Email Verification",
+    "verifyEmailDesc": "Please enter the verification code sent to your email",
+    "verificationCodePlaceholder": "Enter verification code",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "signupButton": "Sign Up",
+    
+    "errorEmpty": {
+      "id": "Please enter your ID.",
+      "email": "Please enter your email.",
+      "nickname": "Please enter your nickname."
+    },
+    "errorInvalid": {
+      "id": "ID cannot contain spaces.",
+      "nickname": "Nickname cannot contain spaces.",
+      "email": "Invalid email format."
+    },
+    "errorDuplicate": {
+      "id": "This ID is already in use.",
+      "email": "This email is already in use.",
+      "nickname": "This nickname is already in use."
+    },
+    "success": {
+      "id": "This ID is available.",
+      "email": "This email is available.",
+      "nickname": "This nickname is available.",
+      "emailVerification": "Email verification completed."
+    },
+    "passwordValidation": {
+      "valid": "Password is valid.",
+      "invalid": "8-20 characters, must include English(with uppercase) + numbers + special characters(!@^*), no spaces/Korean allowed.",
+      "match": "Passwords match.",
+      "mismatch": "Passwords do not match."
+    },
+    "verification": {
+      "sendSuccess": "Verification code sent successfully",
+      "sendError": "Failed to send verification code",
+      "invalidCode": "Invalid verification code.",
+      "error": "An error occurred during verification."
+    },
+    "submit": {
+      "missingItems": "Please complete the following items:",
+      "idCheck": "ID duplicate check",
+      "emailCheck": "Email duplicate check",
+      "emailVerification": "Email verification",
+      "passwordCheck": "Password format check",
+      "passwordMatch": "Password match check",
+      "nicknameCheck": "Nickname duplicate check",
+      "success": "Sign up completed!",
+      "error": "An error occurred during sign up. Please try again later."
+    }
+  },
+
+  "signupComplete": {
+    "title": "WELCOME!",
+    "message": "Sign up completed successfully.",
+    "loginButton": "Login"
   }
 }
   

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3,6 +3,7 @@
   "login": "Iniciar sesión",
   "signup": "Registrarse",
   "search": "Buscar",
+  "logout": "Cerrar sesión",
   "currentLanguage": "Idioma actual",
   "close": "Cerrar",
   "tteokbokki": "Tteokbokki",
@@ -12,52 +13,129 @@
   "amusementpark": "Parque de atracciones",
   "cherryblossom": "Flor de cerezo",
   "movie": "Película",
-  "searchPrompt": "Por favor, introduzca una palabra clave.",
+  "searchPrompt": "Ingrese término de búsqueda",
 
   "loginPage": {
     "title": "Iniciar sesión",
     "idPlaceholder": "Usuario",
     "pwPlaceholder": "Contraseña",
     "rememberMe": "Mantener sesión iniciada",
-    "findAccount": "¿Olvidaste tu usuario o contraseña?",
-    "loginButton": "Entrar",
+    "findAccount": "Buscar Usuario/Contraseña",
+    "loginButton": "Iniciar sesión",
     "signupButton": "Registrarse",
-    "errorEmpty": "Por favor, introduce usuario y contraseña.",
-    "errorInvalid": "Error al iniciar sesión. Verifica tus credenciales.",
+    "errorEmpty": "Por favor, ingrese usuario y contraseña",
+    "errorInvalid": "Error al iniciar sesión. Verifique su usuario y contraseña",
     "success": "¡Bienvenido, {{nickname}}!"
   },
 
   "findAccount": {
-    "title": "Buscar ID / Restablecer contraseña",
-    "idTitle": "Buscar tu ID",
-    "idDesc": "Encuentra tu ID mediante verificación por correo electrónico.",
-    "idButton": "Buscar ID",
-    "pwTitle": "Restablecer contraseña",
-    "pwDesc": "Ingresa tu ID y correo electrónico para restablecer tu contraseña.",
-    "pwButton": "Restablecer contraseña"
+    "title": "Buscar Usuario/Contraseña",
+    "idTitle": "Buscar Usuario",
+    "idDesc": "Encuentre su usuario mediante verificación por correo",
+    "idButton": "Buscar Usuario",
+    "pwTitle": "Restablecer Contraseña",
+    "pwDesc": "Restablezca su contraseña ingresando usuario y correo",
+    "pwButton": "Restablecer"
   },
 
   "findId": {
-    "title": "Buscar ID",
-    "emailPlaceholder": "Introduce tu correo electrónico.",
-    "findButton": "Buscar ID",
-    "success": "Tu ID ha sido enviada al correo electrónico proporcionado.",
-    "goLogin": "Ir a iniciar sesión",
-    "errorEmpty": "Por favor, introduce tu correo electrónico.",
-    "errorNotFound": "No se encontró ninguna ID asociada a ese correo.",
-    "errorServer": "Se produjo un error en el servidor. Inténtalo de nuevo."
+    "title": "Buscar Usuario",
+    "emailPlaceholder": "Ingrese su correo",
+    "findButton": "Buscar Usuario",
+    "success": "Su usuario ha sido enviado a su correo",
+    "goLogin": "Ir a inicio de sesión",
+    "errorEmpty": "Por favor, ingrese su correo",
+    "errorNotFound": "No se encontró usuario para este correo",
+    "errorServer": "Error del servidor. Por favor, intente más tarde"
   },
 
   "resetPassword": {
-    "title": "Restablecer la contraseña",
-    "idPlaceholder": "Introduce tu ID.",
-    "emailPlaceholder": "Introduce tu correo electrónico.",
-    "resetButton": "Restablecer contraseña",
-    "success": "Se ha enviado una contraseña temporal a tu correo electrónico. Cámbiala después de iniciar sesión.",
-    "goLogin": "Ir a iniciar sesión",
-    "errorEmpty": "Introduce tanto el ID como el correo electrónico.",
-    "errorNotFound": "No se encontró información coincidente.",
-    "errorServer": "Ocurrió un error en el servidor. Inténtalo de nuevo."
+    "title": "Restablecer Contraseña",
+    "idPlaceholder": "Ingrese su usuario",
+    "emailPlaceholder": "Ingrese su correo",
+    "resetButton": "Restablecer",
+    "submitting": "Procesando...",
+    "success": "Se ha enviado una contraseña temporal a su correo. Por favor, cámbiela después de iniciar sesión",
+    "goLogin": "Ir a inicio de sesión",
+    "errorEmpty": "Por favor, ingrese usuario y correo",
+    "errorInvalidId": "El usuario debe tener entre 4 y 20 caracteres alfanuméricos",
+    "errorInvalidEmail": "Formato de correo inválido",
+    "errorNotFound": "No se encontró usuario con los datos proporcionados",
+    "errorEmailSend": "Error al enviar el correo. Por favor, intente más tarde",
+    "errorServer": "Error del servidor. Por favor, intente más tarde"
+  },
+
+  "signupPage": {
+    "title": "Registro",
+    "id": "Usuario",
+    "idPlaceholder": "Ingrese su usuario",
+    "email": "Correo",
+    "emailPlaceholder": "Ingrese su correo",
+    "password": "Contraseña",
+    "passwordPlaceholder": "Ingrese su contraseña",
+    "confirmPassword": "Confirmar Contraseña",
+    "confirmPasswordPlaceholder": "Ingrese nuevamente su contraseña",
+    "nickname": "Apodo",
+    "nicknamePlaceholder": "Ingrese su apodo",
+    "checkDuplicate": "Verificar",
+    "getVerificationCode": "Obtener código",
+    "verifyEmail": "Verificación de correo",
+    "verifyEmailDesc": "Por favor, ingrese el código de verificación enviado a su correo",
+    "verificationCodePlaceholder": "Ingrese el código de verificación",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "signupButton": "Registrarse",
+    
+    "errorEmpty": {
+      "id": "Por favor, ingrese su usuario",
+      "email": "Por favor, ingrese su correo",
+      "nickname": "Por favor, ingrese su apodo"
+    },
+    "errorInvalid": {
+      "id": "El usuario no puede contener espacios",
+      "nickname": "El apodo no puede contener espacios",
+      "email": "Formato de correo inválido"
+    },
+    "errorDuplicate": {
+      "id": "Este usuario ya está en uso",
+      "email": "Este correo ya está en uso",
+      "nickname": "Este apodo ya está en uso"
+    },
+    "success": {
+      "id": "Este usuario está disponible",
+      "email": "Este correo está disponible",
+      "nickname": "Este apodo está disponible",
+      "emailVerification": "Verificación de correo completada"
+    },
+    "passwordValidation": {
+      "valid": "Contraseña válida",
+      "invalid": "8-20 caracteres, debe incluir letras (con mayúsculas) + números + caracteres especiales (!@^*), sin espacios/coreano",
+      "match": "Las contraseñas coinciden",
+      "mismatch": "Las contraseñas no coinciden"
+    },
+    "verification": {
+      "sendSuccess": "Código de verificación enviado",
+      "sendError": "Error al enviar el código",
+      "invalidCode": "Código de verificación inválido",
+      "error": "Ocurrió un error durante la verificación"
+    },
+    "submit": {
+      "missingItems": "Por favor, complete los siguientes elementos:",
+      "idCheck": "Verificación de usuario",
+      "emailCheck": "Verificación de correo",
+      "emailVerification": "Verificación de correo",
+      "passwordCheck": "Verificación de formato de contraseña",
+      "passwordMatch": "Verificación de coincidencia de contraseñas",
+      "nicknameCheck": "Verificación de apodo",
+      "success": "¡Registro completado!",
+      "error": "Ocurrió un error durante el registro. Por favor, intente más tarde"
+    }
+  },
+
+  "signupComplete": {
+    "title": "¡BIENVENIDO!",
+    "message": "Registro completado exitosamente",
+    "loginButton": "Iniciar sesión"
   }
 }
 

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,8 +1,9 @@
 {
-  "language.select": "Choisir la langue",
+  "language.select": "Sélectionner la langue",
   "login": "Connexion",
-  "signup": "Créer un compte",
-  "search": "Recherche",
+  "signup": "Inscription",
+  "search": "Rechercher",
+  "logout": "Déconnexion",
   "currentLanguage": "Langue actuelle",
   "close": "Fermer",
   "tteokbokki": "Tteokbokki",
@@ -10,54 +11,131 @@
   "bts": "BTS",
   "bibimbap": "Bibimbap",
   "amusementpark": "Parc d'attractions",
-  "cherryblossom": "Fleur de cerisier",
+  "cherryblossom": "Fleurs de cerisier",
   "movie": "Film",
-  "searchPrompt": "Veuillez entrer un mot-clé de recherche.",
+  "searchPrompt": "Entrez un terme de recherche",
 
   "loginPage": {
     "title": "Connexion",
     "idPlaceholder": "Identifiant",
     "pwPlaceholder": "Mot de passe",
-    "rememberMe": "Rester connecté",
-    "findAccount": "Identifiant/Mot de passe oublié",
+    "rememberMe": "Se souvenir de moi",
+    "findAccount": "Retrouver ID/Mot de passe",
     "loginButton": "Se connecter",
-    "signupButton": "Créer un compte",
-    "errorEmpty": "Veuillez saisir votre identifiant et votre mot de passe.",
-    "errorInvalid": "Échec de la connexion. Vérifiez vos identifiants.",
+    "signupButton": "S'inscrire",
+    "errorEmpty": "Veuillez saisir l'identifiant et le mot de passe",
+    "errorInvalid": "Échec de la connexion. Vérifiez votre identifiant et mot de passe",
     "success": "Bienvenue, {{nickname}} !"
   },
 
   "findAccount": {
-    "title": "Trouver un identifiant / Réinitialiser le mot de passe",
-    "idTitle": "Trouver votre identifiant",
-    "idDesc": "Trouvez votre identifiant via la vérification par e-mail.",
-    "idButton": "Trouver l'identifiant",
+    "title": "Retrouver ID/Mot de passe",
+    "idTitle": "Retrouver ID",
+    "idDesc": "Retrouvez votre ID par vérification email",
+    "idButton": "Retrouver ID",
     "pwTitle": "Réinitialiser le mot de passe",
-    "pwDesc": "Entrez votre identifiant et votre e-mail pour réinitialiser le mot de passe.",
-    "pwButton": "Réinitialiser le mot de passe"
+    "pwDesc": "Réinitialisez votre mot de passe en saisissant votre ID et email",
+    "pwButton": "Réinitialiser"
   },
 
   "findId": {
-    "title": "Trouver un identifiant",
-    "emailPlaceholder": "Entrez votre adresse e-mail.",
-    "findButton": "Trouver l'identifiant",
-    "success": "Votre identifiant a été envoyé à l'adresse e-mail saisie.",
+    "title": "Retrouver ID",
+    "emailPlaceholder": "Entrez votre email",
+    "findButton": "Retrouver ID",
+    "success": "Votre ID a été envoyé à votre email",
     "goLogin": "Aller à la connexion",
-    "errorEmpty": "Veuillez entrer votre adresse e-mail.",
-    "errorNotFound": "Aucun identifiant n’est associé à cette adresse e-mail.",
-    "errorServer": "Une erreur serveur s'est produite. Veuillez réessayer."
+    "errorEmpty": "Veuillez saisir votre email",
+    "errorNotFound": "Aucun ID trouvé pour cet email",
+    "errorServer": "Erreur serveur. Veuillez réessayer plus tard"
   },
 
   "resetPassword": {
     "title": "Réinitialiser le mot de passe",
-    "idPlaceholder": "Entrez votre identifiant.",
-    "emailPlaceholder": "Entrez votre adresse e-mail.",
-    "resetButton": "Réinitialiser le mot de passe",
-    "success": "Un mot de passe temporaire a été envoyé à votre e-mail. Veuillez le modifier après connexion.",
+    "idPlaceholder": "Entrez votre identifiant",
+    "emailPlaceholder": "Entrez votre email",
+    "resetButton": "Réinitialiser",
+    "submitting": "Traitement en cours...",
+    "success": "Un mot de passe temporaire a été envoyé à votre email. Veuillez le modifier après la connexion",
     "goLogin": "Aller à la connexion",
-    "errorEmpty": "Veuillez saisir à la fois l'identifiant et l'e-mail.",
-    "errorNotFound": "Aucune information correspondante trouvée.",
-    "errorServer": "Une erreur serveur s'est produite. Veuillez réessayer."
+    "errorEmpty": "Veuillez saisir l'identifiant et l'email",
+    "errorInvalidId": "L'identifiant doit contenir 4 à 20 caractères alphanumériques",
+    "errorInvalidEmail": "Format d'email invalide",
+    "errorNotFound": "Aucun utilisateur trouvé avec l'identifiant et l'email fournis",
+    "errorEmailSend": "Échec de l'envoi de l'email. Veuillez réessayer plus tard",
+    "errorServer": "Erreur serveur. Veuillez réessayer plus tard"
+  },
+
+  "signupPage": {
+    "title": "Inscription",
+    "id": "Identifiant",
+    "idPlaceholder": "Entrez votre identifiant",
+    "email": "Email",
+    "emailPlaceholder": "Entrez votre email",
+    "password": "Mot de passe",
+    "passwordPlaceholder": "Entrez votre mot de passe",
+    "confirmPassword": "Confirmer le mot de passe",
+    "confirmPasswordPlaceholder": "Entrez à nouveau votre mot de passe",
+    "nickname": "Pseudo",
+    "nicknamePlaceholder": "Entrez votre pseudo",
+    "checkDuplicate": "Vérifier",
+    "getVerificationCode": "Obtenir le code",
+    "verifyEmail": "Vérification email",
+    "verifyEmailDesc": "Veuillez entrer le code de vérification envoyé à votre email",
+    "verificationCodePlaceholder": "Entrez le code de vérification",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "signupButton": "S'inscrire",
+    
+    "errorEmpty": {
+      "id": "Veuillez entrer votre identifiant",
+      "email": "Veuillez entrer votre email",
+      "nickname": "Veuillez entrer votre pseudo"
+    },
+    "errorInvalid": {
+      "id": "L'identifiant ne peut pas contenir d'espaces",
+      "nickname": "Le pseudo ne peut pas contenir d'espaces",
+      "email": "Format d'email invalide"
+    },
+    "errorDuplicate": {
+      "id": "Cet identifiant est déjà utilisé",
+      "email": "Cet email est déjà utilisé",
+      "nickname": "Ce pseudo est déjà utilisé"
+    },
+    "success": {
+      "id": "Cet identifiant est disponible",
+      "email": "Cet email est disponible",
+      "nickname": "Ce pseudo est disponible",
+      "emailVerification": "Vérification email terminée"
+    },
+    "passwordValidation": {
+      "valid": "Mot de passe valide",
+      "invalid": "8-20 caractères, doit inclure lettres (avec majuscules) + chiffres + caractères spéciaux (!@^*), pas d'espaces/coréen",
+      "match": "Les mots de passe correspondent",
+      "mismatch": "Les mots de passe ne correspondent pas"
+    },
+    "verification": {
+      "sendSuccess": "Code de vérification envoyé",
+      "sendError": "Échec de l'envoi du code",
+      "invalidCode": "Code de vérification invalide",
+      "error": "Une erreur est survenue lors de la vérification"
+    },
+    "submit": {
+      "missingItems": "Veuillez compléter les éléments suivants :",
+      "idCheck": "Vérification de l'identifiant",
+      "emailCheck": "Vérification de l'email",
+      "emailVerification": "Vérification email",
+      "passwordCheck": "Vérification du format du mot de passe",
+      "passwordMatch": "Vérification de la correspondance des mots de passe",
+      "nicknameCheck": "Vérification du pseudo",
+      "success": "Inscription terminée !",
+      "error": "Une erreur est survenue lors de l'inscription. Veuillez réessayer plus tard"
+    }
+  },
+
+  "signupComplete": {
+    "title": "BIENVENUE !",
+    "message": "Inscription terminée avec succès",
+    "loginButton": "Connexion"
   }
 }
 

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -3,6 +3,7 @@
   "login": "ログイン",
   "signup": "新規登録",
   "search": "検索",
+  "logout": "ログアウト",
   "currentLanguage": "現在の言語",
   "close": "閉じる",
   "tteokbokki": "トッポッキ",
@@ -50,13 +51,90 @@
 
   "resetPassword": {
     "title": "パスワード再設定",
-    "idPlaceholder": "IDを入力してください。",
-    "emailPlaceholder": "メールアドレスを入力してください。",
+    "idPlaceholder": "IDを入力してください",
+    "emailPlaceholder": "メールアドレスを入力してください",
     "resetButton": "パスワードを再設定する",
-    "success": "仮パスワードをメールに送信しました。ログイン後、必ずパスワードを変更してください。",
+    "submitting": "処理中...",
+    "success": "仮パスワードをメールに送信しました。ログイン後、必ずパスワードを変更してください",
     "goLogin": "ログインページへ",
-    "errorEmpty": "IDとメールアドレスを両方入力してください。",
-    "errorNotFound": "一致する情報が見つかりませんでした。",
-    "errorServer": "サーバーエラーが発生しました。もう一度お試しください。"
+    "errorEmpty": "IDとメールアドレスを両方入力してください",
+    "errorInvalidId": "IDは半角英数字4-20文字で入力してください",
+    "errorInvalidEmail": "メールアドレスの形式が正しくありません",
+    "errorNotFound": "一致する情報が見つかりませんでした",
+    "errorEmailSend": "メール送信に失敗しました。後でもう一度お試しください",
+    "errorServer": "サーバーエラーが発生しました。もう一度お試しください"
+  },
+
+  "signupPage": {
+    "title": "新規登録",
+    "id": "ID",
+    "idPlaceholder": "IDを入力してください",
+    "email": "メールアドレス",
+    "emailPlaceholder": "メールアドレスを入力してください",
+    "password": "パスワード",
+    "passwordPlaceholder": "パスワードを入力してください",
+    "confirmPassword": "パスワード（確認）",
+    "confirmPasswordPlaceholder": "パスワードをもう一度入力してください",
+    "nickname": "ニックネーム",
+    "nicknamePlaceholder": "ニックネームを入力してください",
+    "checkDuplicate": "重複確認",
+    "getVerificationCode": "認証コードを取得",
+    "verifyEmail": "メール認証",
+    "verifyEmailDesc": "メールに送信された認証コードを入力してください",
+    "verificationCodePlaceholder": "認証コードを入力",
+    "cancel": "キャンセル",
+    "confirm": "確認",
+    "signupButton": "登録する",
+    
+    "errorEmpty": {
+      "id": "IDを入力してください",
+      "email": "メールアドレスを入力してください",
+      "nickname": "ニックネームを入力してください"
+    },
+    "errorInvalid": {
+      "id": "IDにスペースは使用できません",
+      "nickname": "ニックネームにスペースは使用できません",
+      "email": "メールアドレスの形式が正しくありません"
+    },
+    "errorDuplicate": {
+      "id": "このIDは既に使用されています",
+      "email": "このメールアドレスは既に使用されています",
+      "nickname": "このニックネームは既に使用されています"
+    },
+    "success": {
+      "id": "このIDは使用可能です",
+      "email": "このメールアドレスは使用可能です",
+      "nickname": "このニックネームは使用可能です",
+      "emailVerification": "メール認証が完了しました"
+    },
+    "passwordValidation": {
+      "valid": "パスワードは使用可能です",
+      "invalid": "8-20文字で、英字（大文字含む）+数字+記号(!@^*)を含める必要があります。スペース/韓国語は使用できません",
+      "match": "パスワードが一致します",
+      "mismatch": "パスワードが一致しません"
+    },
+    "verification": {
+      "sendSuccess": "認証コードを送信しました",
+      "sendError": "認証コードの送信に失敗しました",
+      "invalidCode": "認証コードが正しくありません",
+      "error": "認証中にエラーが発生しました"
+    },
+    "submit": {
+      "missingItems": "以下の項目を完了してください：",
+      "idCheck": "ID重複確認",
+      "emailCheck": "メールアドレス重複確認",
+      "emailVerification": "メール認証",
+      "passwordCheck": "パスワード形式確認",
+      "passwordMatch": "パスワード一致確認",
+      "nicknameCheck": "ニックネーム重複確認",
+      "success": "登録が完了しました！",
+      "error": "登録処理中にエラーが発生しました。後でもう一度お試しください"
+    }
+  },
+
+  "signupComplete": {
+    "title": "ようこそ！",
+    "message": "登録が完了しました",
+    "loginButton": "ログイン"
   }
-  }
+}

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -3,6 +3,7 @@
   "login": "로그인",
   "signup": "회원가입",
   "search": "검색",
+  "logout": "로그아웃",
   "currentLanguage": "현재 언어",
   "close": "닫기",
   "tteokbokki": "떡볶이",
@@ -55,11 +56,88 @@
     "idPlaceholder": "아이디를 입력하세요.",
     "emailPlaceholder": "이메일을 입력하세요.",
     "resetButton": "비밀번호 재설정",
+    "submitting": "처리 중...",
     "success": "입력하신 이메일로 임시 비밀번호를 전송했습니다. 로그인 후 반드시 비밀번호를 변경해주세요.",
     "goLogin": "로그인하러 가기",
     "errorEmpty": "아이디와 이메일을 모두 입력해주세요.",
-    "errorNotFound": "일치하는 정보가 없습니다.",
-    "errorServer": "서버 오류가 발생했습니다. 다시 시도해주세요."
+    "errorInvalidId": "아이디는 영문과 숫자 조합으로 4~20자 이내로 입력해주세요.",
+    "errorInvalidEmail": "올바른 이메일 형식이 아닙니다.",
+    "errorNotFound": "입력하신 아이디와 이메일이 일치하는 사용자를 찾을 수 없습니다.",
+    "errorEmailSend": "이메일 전송에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    "errorServer": "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+  },
+
+  "signupPage": {
+    "title": "회원 가입",
+    "id": "아이디",
+    "idPlaceholder": "아이디를 입력하세요.",
+    "email": "이메일",
+    "emailPlaceholder": "이메일을 입력하세요.",
+    "password": "비밀번호",
+    "passwordPlaceholder": "비밀번호를 입력하세요.",
+    "confirmPassword": "비밀번호 확인",
+    "confirmPasswordPlaceholder": "비밀번호를 한번 더 입력하세요.",
+    "nickname": "닉네임",
+    "nicknamePlaceholder": "닉네임을 입력하세요.",
+    "checkDuplicate": "중복 확인",
+    "getVerificationCode": "인증 코드 받기",
+    "verifyEmail": "이메일 인증",
+    "verifyEmailDesc": "입력하신 이메일로 전송된 인증 코드를 입력해주세요.",
+    "verificationCodePlaceholder": "인증 코드 입력",
+    "cancel": "취소",
+    "confirm": "확인",
+    "signupButton": "회원 가입",
+    
+    "errorEmpty": {
+      "id": "아이디를 입력해주세요.",
+      "email": "이메일을 입력해주세요.",
+      "nickname": "닉네임을 입력해주세요."
+    },
+    "errorInvalid": {
+      "id": "아이디에는 공백을 포함할 수 없습니다.",
+      "nickname": "닉네임에는 공백을 포함할 수 없습니다.",
+      "email": "올바른 이메일 형식이 아닙니다."
+    },
+    "errorDuplicate": {
+      "id": "이미 사용 중인 아이디입니다.",
+      "email": "이미 사용 중인 이메일입니다.",
+      "nickname": "이미 사용 중인 닉네임입니다."
+    },
+    "success": {
+      "id": "사용 가능한 아이디입니다.",
+      "email": "사용 가능한 이메일입니다.",
+      "nickname": "사용 가능한 닉네임입니다.",
+      "emailVerification": "이메일 인증이 완료되었습니다."
+    },
+    "passwordValidation": {
+      "valid": "사용 가능한 비밀번호입니다.",
+      "invalid": "8~20자, 영문(대문자 포함) + 숫자 + 특수문자(!@^*)를 포함해야 하며 공백/한글은 사용할 수 없습니다.",
+      "match": "비밀번호가 일치합니다.",
+      "mismatch": "비밀번호가 일치하지 않습니다."
+    },
+    "verification": {
+      "sendSuccess": "인증 코드 전송 성공",
+      "sendError": "이메일 인증 코드 전송 실패",
+      "invalidCode": "인증 코드가 올바르지 않습니다.",
+      "error": "인증 과정에서 오류가 발생했습니다."
+    },
+    "submit": {
+      "missingItems": "다음 항목을 완료해주세요:",
+      "idCheck": "아이디 중복 확인",
+      "emailCheck": "이메일 중복 확인",
+      "emailVerification": "이메일 인증",
+      "passwordCheck": "비밀번호 형식 확인",
+      "passwordMatch": "비밀번호 일치 확인",
+      "nicknameCheck": "닉네임 중복 확인",
+      "success": "회원가입이 완료되었습니다!",
+      "error": "회원가입 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+    }
+  },
+
+  "signupComplete": {
+    "title": "WELCOME!",
+    "message": "회원가입이 완료되었습니다.",
+    "loginButton": "로그인"
   }
 }
 

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,62 +1,140 @@
 {
    "language.select": "Выбрать язык",
    "login": "Войти",
-   "signup": "Зарегистрироваться",
+   "signup": "Регистрация",
    "search": "Поиск",
+   "logout": "Выйти",
    "currentLanguage": "Текущий язык",
    "close": "Закрыть",
    "tteokbokki": "Ттокпокки",
-   "kpop": "К-поп",
+   "kpop": "K-pop",
    "bts": "BTS",
-   "bibimbap": "Пибимпаб",
-   "amusementpark": "Парк аттракционов",
-   "cherryblossom": "Цветение вишни",
+   "bibimbap": "Пибимпап",
+   "amusementpark": "Парк развлечений",
+   "cherryblossom": "Цветение сакуры",
    "movie": "Фильм",
-   "searchPrompt": "Пожалуйста, введите поисковый запрос.",
+   "searchPrompt": "Введите поисковый запрос",
 
   "loginPage": {
     "title": "Вход",
     "idPlaceholder": "Логин",
     "pwPlaceholder": "Пароль",
-    "rememberMe": "Оставаться в системе",
-    "findAccount": "Забыли логин или пароль?",
+    "rememberMe": "Запомнить меня",
+    "findAccount": "Найти логин/пароль",
     "loginButton": "Войти",
     "signupButton": "Регистрация",
-    "errorEmpty": "Пожалуйста, введите логин и пароль.",
-    "errorInvalid": "Ошибка входа. Проверьте правильность введённых данных.",
+    "errorEmpty": "Пожалуйста, введите логин и пароль",
+    "errorInvalid": "Ошибка входа. Проверьте логин и пароль",
     "success": "Добро пожаловать, {{nickname}}!"
   },
 
   "findAccount": {
-    "title": "Поиск ID / Сброс пароля",
-    "idTitle": "Найти ID",
-    "idDesc": "Найдите свой ID через подтверждение по электронной почте.",
-    "idButton": "Найти ID",
-    "pwTitle": "Сброс пароля",
-    "pwDesc": "Введите свой ID и адрес электронной почты для сброса пароля.",
-    "pwButton": "Сбросить пароль"
+    "title": "Найти логин/пароль",
+    "idTitle": "Найти логин",
+    "idDesc": "Найдите свой логин через подтверждение по email",
+    "idButton": "Найти логин",
+    "pwTitle": "Сбросить пароль",
+    "pwDesc": "Сбросьте пароль, указав логин и email",
+    "pwButton": "Сбросить"
   },
 
   "findId": {
-    "title": "Поиск ID",
-    "emailPlaceholder": "Введите свой адрес электронной почты.",
-    "findButton": "Найти ID",
-    "success": "ID отправлен на указанный вами адрес электронной почты.",
-    "goLogin": "Перейти ко входу",
-    "errorEmpty": "Пожалуйста, введите адрес электронной почты.",
-    "errorNotFound": "Для этой электронной почты ID не найден.",
-    "errorServer": "Произошла ошибка сервера. Попробуйте позже."
+    "title": "Найти логин",
+    "emailPlaceholder": "Введите email",
+    "findButton": "Найти логин",
+    "success": "Ваш логин отправлен на email",
+    "goLogin": "Перейти к входу",
+    "errorEmpty": "Пожалуйста, введите email",
+    "errorNotFound": "Логин для этого email не найден",
+    "errorServer": "Ошибка сервера. Попробуйте позже"
   },
 
   "resetPassword": {
     "title": "Сброс пароля",
-    "idPlaceholder": "Введите ваш логин.",
-    "emailPlaceholder": "Введите вашу электронную почту.",
-    "resetButton": "Сбросить пароль",
-    "success": "Временный пароль отправлен на вашу почту. Пожалуйста, смените его после входа.",
-    "goLogin": "Перейти ко входу",
-    "errorEmpty": "Пожалуйста, введите логин и почту.",
-    "errorNotFound": "Совпадений не найдено.",
-    "errorServer": "Произошла ошибка сервера. Повторите попытку позже."
+    "idPlaceholder": "Введите логин",
+    "emailPlaceholder": "Введите email",
+    "resetButton": "Сбросить",
+    "submitting": "Обработка...",
+    "success": "Временный пароль отправлен на ваш email. Пожалуйста, измените его после входа",
+    "goLogin": "Перейти к входу",
+    "errorEmpty": "Пожалуйста, введите логин и email",
+    "errorInvalidId": "Логин должен содержать от 4 до 20 буквенно-цифровых символов",
+    "errorInvalidEmail": "Неверный формат email",
+    "errorNotFound": "Пользователь с указанными данными не найден",
+    "errorEmailSend": "Ошибка отправки email. Попробуйте позже",
+    "errorServer": "Ошибка сервера. Попробуйте позже"
+  },
+
+  "signupPage": {
+    "title": "Регистрация",
+    "id": "Логин",
+    "idPlaceholder": "Введите логин",
+    "email": "Email",
+    "emailPlaceholder": "Введите email",
+    "password": "Пароль",
+    "passwordPlaceholder": "Введите пароль",
+    "confirmPassword": "Подтверждение пароля",
+    "confirmPasswordPlaceholder": "Введите пароль ещё раз",
+    "nickname": "Никнейм",
+    "nicknamePlaceholder": "Введите никнейм",
+    "checkDuplicate": "Проверить",
+    "getVerificationCode": "Получить код",
+    "verifyEmail": "Подтверждение email",
+    "verifyEmailDesc": "Пожалуйста, введите код подтверждения, отправленный на ваш email",
+    "verificationCodePlaceholder": "Введите код подтверждения",
+    "cancel": "Отмена",
+    "confirm": "Подтвердить",
+    "signupButton": "Зарегистрироваться",
+    
+    "errorEmpty": {
+      "id": "Пожалуйста, введите логин",
+      "email": "Пожалуйста, введите email",
+      "nickname": "Пожалуйста, введите никнейм"
+    },
+    "errorInvalid": {
+      "id": "Логин не может содержать пробелы",
+      "nickname": "Никнейм не может содержать пробелы",
+      "email": "Неверный формат email"
+    },
+    "errorDuplicate": {
+      "id": "Этот логин уже используется",
+      "email": "Этот email уже используется",
+      "nickname": "Этот никнейм уже используется"
+    },
+    "success": {
+      "id": "Этот логин доступен",
+      "email": "Этот email доступен",
+      "nickname": "Этот никнейм доступен",
+      "emailVerification": "Email подтверждён"
+    },
+    "passwordValidation": {
+      "valid": "Пароль подходит",
+      "invalid": "8-20 символов, должен включать буквы (с заглавными) + цифры + специальные символы (!@^*), без пробелов/корейского",
+      "match": "Пароли совпадают",
+      "mismatch": "Пароли не совпадают"
+    },
+    "verification": {
+      "sendSuccess": "Код подтверждения отправлен",
+      "sendError": "Ошибка отправки кода",
+      "invalidCode": "Неверный код подтверждения",
+      "error": "Произошла ошибка при подтверждении"
+    },
+    "submit": {
+      "missingItems": "Пожалуйста, выполните следующие пункты:",
+      "idCheck": "Проверка логина",
+      "emailCheck": "Проверка email",
+      "emailVerification": "Подтверждение email",
+      "passwordCheck": "Проверка формата пароля",
+      "passwordMatch": "Проверка совпадения паролей",
+      "nicknameCheck": "Проверка никнейма",
+      "success": "Регистрация завершена!",
+      "error": "Произошла ошибка при регистрации. Попробуйте позже"
+    }
+  },
+
+  "signupComplete": {
+    "title": "ДОБРО ПОЖАЛОВАТЬ!",
+    "message": "Регистрация успешно завершена",
+    "loginButton": "Войти"
   }
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -3,6 +3,7 @@
     "login": "登录",
     "signup": "注册",
     "search": "搜索",
+    "logout": "退出登录",
     "currentLanguage": "当前语言",
     "close": "关闭",
     "tteokbokki": "炒年糕",
@@ -50,13 +51,90 @@
 
     "resetPassword": {
     "title": "重置密码",
-    "idPlaceholder": "请输入您的账号。",
-    "emailPlaceholder": "请输入您的邮箱。",
+    "idPlaceholder": "请输入账号",
+    "emailPlaceholder": "请输入邮箱",
     "resetButton": "重置密码",
-    "success": "临时密码已发送至您的邮箱。登录后请尽快修改密码。",
+    "submitting": "处理中...",
+    "success": "临时密码已发送至您的邮箱。登录后请务必修改密码",
     "goLogin": "前往登录",
-    "errorEmpty": "请同时输入账号和邮箱。",
-    "errorNotFound": "未找到匹配的信息。",
-    "errorServer": "服务器错误，请稍后重试。"
+    "errorEmpty": "请输入账号和邮箱",
+    "errorInvalidId": "账号必须为4-20位字母数字组合",
+    "errorInvalidEmail": "邮箱格式不正确",
+    "errorNotFound": "未找到匹配的账号和邮箱",
+    "errorEmailSend": "邮件发送失败，请稍后重试",
+    "errorServer": "服务器错误，请稍后重试"
+    },
+
+    "signupPage": {
+        "title": "注册",
+        "id": "账号",
+        "idPlaceholder": "请输入账号",
+        "email": "邮箱",
+        "emailPlaceholder": "请输入邮箱",
+        "password": "密码",
+        "passwordPlaceholder": "请输入密码",
+        "confirmPassword": "确认密码",
+        "confirmPasswordPlaceholder": "请再次输入密码",
+        "nickname": "昵称",
+        "nicknamePlaceholder": "请输入昵称",
+        "checkDuplicate": "查重",
+        "getVerificationCode": "获取验证码",
+        "verifyEmail": "邮箱验证",
+        "verifyEmailDesc": "请输入发送到您邮箱的验证码",
+        "verificationCodePlaceholder": "请输入验证码",
+        "cancel": "取消",
+        "confirm": "确认",
+        "signupButton": "注册",
+        
+        "errorEmpty": {
+            "id": "请输入账号",
+            "email": "请输入邮箱",
+            "nickname": "请输入昵称"
+        },
+        "errorInvalid": {
+            "id": "账号不能包含空格",
+            "nickname": "昵称不能包含空格",
+            "email": "邮箱格式不正确"
+        },
+        "errorDuplicate": {
+            "id": "该账号已被使用",
+            "email": "该邮箱已被使用",
+            "nickname": "该昵称已被使用"
+        },
+        "success": {
+            "id": "该账号可以使用",
+            "email": "该邮箱可以使用",
+            "nickname": "该昵称可以使用",
+            "emailVerification": "邮箱验证完成"
+        },
+        "passwordValidation": {
+            "valid": "密码可以使用",
+            "invalid": "密码必须为8-20位，包含英文（含大写）+数字+特殊字符(!@^*)，不允许空格/韩文",
+            "match": "密码匹配",
+            "mismatch": "密码不匹配"
+        },
+        "verification": {
+            "sendSuccess": "验证码发送成功",
+            "sendError": "验证码发送失败",
+            "invalidCode": "验证码无效",
+            "error": "验证过程中出现错误"
+        },
+        "submit": {
+            "missingItems": "请完成以下项目：",
+            "idCheck": "账号查重",
+            "emailCheck": "邮箱查重",
+            "emailVerification": "邮箱验证",
+            "passwordCheck": "密码格式检查",
+            "passwordMatch": "密码匹配检查",
+            "nicknameCheck": "昵称查重",
+            "success": "注册成功！",
+            "error": "注册过程中出现错误，请稍后重试"
+        }
+    },
+
+    "signupComplete": {
+        "title": "欢迎！",
+        "message": "注册成功",
+        "loginButton": "登录"
     }
 }

--- a/src/pages/Login/LoginPage.jsx
+++ b/src/pages/Login/LoginPage.jsx
@@ -2,6 +2,7 @@ import { loginUser } from '../../components/ui/loginPage/loginApi.ts';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import React, { useState, useEffect } from 'react';
+import { loginStatusChange } from '../../components/common/Header';
 
 export default function LoginPage() {
 
@@ -23,12 +24,11 @@ export default function LoginPage() {
 
     const result = await loginUser({ loginId, password });
 
-    if (result) {
-      // 로컬스토리지 저장
-      localStorage.setItem('token', result.token);
-      localStorage.setItem('userId', result.userId);
-      localStorage.setItem('nickname', result.nickname);
-      localStorage.setItem('languageCode', result.languageCode);
+    if (result && result.success) {
+      // sessionId를 토큰으로 저장
+      if (result.sessionId) {
+        localStorage.setItem('token', result.sessionId);
+      }
 
       // 로그인 상태 유지 여부 저장
       if (rememberMe) {
@@ -37,9 +37,14 @@ export default function LoginPage() {
         localStorage.removeItem('rememberMe');
       }
 
+      // 로그인 상태 변경 이벤트 발생
+      window.dispatchEvent(loginStatusChange);
+
       // 환영 메시지 및 이동
-      alert(t('loginPage.success', { nickname: result.nickname }));
-      navigate('/main');
+      alert(t('loginPage.success', { nickname: loginId }));
+      
+      // 페이지 이동
+      navigate('/home');
     } else {
       setErrorMessage('loginPage.errorInvalid');
     }
@@ -53,7 +58,7 @@ export default function LoginPage() {
     const token = localStorage.getItem('token');
   
     if (remembered === 'true' && token) {
-      navigate('/main');
+      navigate('/home');
     }
   }, []);
 
@@ -132,8 +137,8 @@ export default function LoginPage() {
 
             {/* 회원가입 버튼 */}
             <button
-              className="w-full py-4 border border-gray-300 text-gray-400 rounded-md cursor-not-allowed text-xl"
-              disabled
+              className="w-full py-4 border border-gray-300 text-gray-400 rounded-md text-xl hover:bg-gray-100 transition"
+              onClick={() => navigate('/signup')}
             >
               {t('loginPage.signupButton')}
             </button>

--- a/src/pages/Login/ResetPasswordPage.jsx
+++ b/src/pages/Login/ResetPasswordPage.jsx
@@ -11,26 +11,78 @@ export default function ResetPasswordPage() {
   const [email, setEmail] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 이메일 형식 검증
+  const isValidEmail = (email) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+  };
+
+  // 아이디 형식 검증 (영문, 숫자 조합 4~20자)
+  const isValidId = (id) => {
+    const idRegex = /^[A-Za-z0-9]{4,20}$/;
+    return idRegex.test(id);
+  };
 
   const handleResetPassword = async () => {
+    // 중복 제출 방지
+    if (isSubmitting) return;
+
+    // 입력값 존재 여부 확인
     if (!loginId || !email) {
       setErrorMessage(t('resetPassword.errorEmpty'));
       setSuccessMessage('');
       return;
     }
 
+    // 아이디 형식 검증
+    if (!isValidId(loginId)) {
+      setErrorMessage(t('resetPassword.errorInvalidId'));
+      setSuccessMessage('');
+      return;
+    }
+
+    // 이메일 형식 검증
+    if (!isValidEmail(email)) {
+      setErrorMessage(t('resetPassword.errorInvalidEmail'));
+      setSuccessMessage('');
+      return;
+    }
+
     try {
-      const ok = await resetPasswordRequest({ loginId, email });
-      if (ok) {
-        setSuccessMessage(t('resetPassword.success'));
-        setErrorMessage('');
+      setIsSubmitting(true);
+      const result = await resetPasswordRequest({ loginId, email });
+      
+      if (result) {
+        if (result.success && result.userVerified && result.emailSent) {
+          setSuccessMessage(t('resetPassword.success'));
+          setErrorMessage('');
+          // 입력 필드 초기화
+          setLoginId('');
+          setEmail('');
+        } else {
+          // 실패 케이스별 메시지 처리
+          let errorKey = 'resetPassword.errorServer';
+          
+          if (!result.userVerified) {
+            errorKey = 'resetPassword.errorNotFound';
+          } else if (!result.emailSent) {
+            errorKey = 'resetPassword.errorEmailSend';
+          }
+          
+          setErrorMessage(t(errorKey));
+          setSuccessMessage('');
+        }
       } else {
-        setErrorMessage(t('resetPassword.errorNotFound'));
+        setErrorMessage(t('resetPassword.errorServer'));
         setSuccessMessage('');
       }
     } catch (e) {
       setErrorMessage(t('resetPassword.errorServer'));
       setSuccessMessage('');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -57,7 +109,8 @@ export default function ResetPasswordPage() {
                 placeholder={t('resetPassword.idPlaceholder')}
                 value={loginId}
                 onChange={(e) => setLoginId(e.target.value)}
-                className="w-full px-4 py-3 border-2 border-gray-400 rounded-md mb-4 placeholder-gray-400 focus:outline-none"
+                disabled={isSubmitting}
+                className="w-full px-4 py-3 border-2 border-gray-400 rounded-md mb-4 placeholder-gray-400 focus:outline-none disabled:bg-gray-100"
             />
             
             <input
@@ -65,11 +118,18 @@ export default function ResetPasswordPage() {
                 placeholder={t('resetPassword.emailPlaceholder')}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full px-4 py-3 border-2 border-gray-400 rounded-md mb-4 placeholder-gray-400 focus:outline-none"
+                disabled={isSubmitting}
+                className="w-full px-4 py-3 border-2 border-gray-400 rounded-md mb-4 placeholder-gray-400 focus:outline-none disabled:bg-gray-100"
             />
 
-            <button type="submit" className="w-full py-3 bg-gray-500 text-white font-semibold rounded-md">
-                {t('resetPassword.resetButton')}
+            <button 
+                type="submit" 
+                disabled={isSubmitting}
+                className={`w-full py-3 text-white font-semibold rounded-md transition-colors ${
+                  isSubmitting ? 'bg-gray-400 cursor-not-allowed' : 'bg-gray-500 hover:bg-gray-600'
+                }`}
+            >
+                {isSubmitting ? t('resetPassword.submitting') : t('resetPassword.resetButton')}
             </button>
         </form>
 

--- a/src/pages/Signup/SignupCompletePage.jsx
+++ b/src/pages/Signup/SignupCompletePage.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+export default function SignupCompletePage() {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  const handleLoginRedirect = () => {
+    navigate('/login');
+  };
+
+  return (
+    <div className="flex flex-col justify-center items-center h-screen bg-white px-4">
+      <h1 className="text-8xl font-extrabold tracking-wide mb-10 font-[Jua] text-center">{t('signupComplete.title')}</h1>
+      <hr className="w-96 border-gray-400 mb-8" />
+      <p className="text-3xl text-gray-800 mb-14">{t('signupComplete.message')}</p>
+      <button
+        onClick={handleLoginRedirect}
+        className="bg-gray-800 text-white w-96 py-4 text-xl rounded-md hover:bg-gray-700 transition"
+      >
+        {t('signupComplete.loginButton')}
+      </button>
+    </div>
+  );
+}

--- a/src/pages/Signup/SignupPage.jsx
+++ b/src/pages/Signup/SignupPage.jsx
@@ -1,0 +1,424 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+    checkLoginId,
+    checkEmail,
+    checkNickname,
+    sendEmailCode,
+    verifyEmailCode,
+    signupUser,
+  } from '../../components/ui/signupPage/userCheckApi.ts';
+  
+  export default function SignupForm() {
+    const { t } = useTranslation();
+    const [form, setForm] = useState({
+      loginId: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+      nickname: ''
+    });
+  
+    const navigate = useNavigate();
+  
+    const [idCheckMessage, setIdCheckMessage] = useState('');
+    const [nicknameCheckMessage, setNicknameCheckMessage] = useState('');
+    const [emailCheckMessage, setEmailCheckMessage] = useState('');
+  
+    const [isIdChecked, setIsIdChecked] = useState(null);
+    const [isNicknameChecked, setIsNicknameChecked] = useState(null);
+    const [isEmailChecked, setIsEmailChecked] = useState(false);
+    const [isEmailVerified, setIsEmailVerified] = useState(false);
+  
+    const [passwordMatchMessage, setPasswordMatchMessage] = useState('');
+    const [isPasswordMatched, setIsPasswordMatched] = useState(null);
+  
+    const [passwordValidMessage, setPasswordValidMessage] = useState('');
+    const [isPasswordValid, setIsPasswordValid] = useState(null);
+  
+    const [showVerificationModal, setShowVerificationModal] = useState(false);
+    const [verificationCode, setVerificationCode] = useState('');
+    const [verifyMessage, setVerifyMessage] = useState('');
+  
+    const handleChange = (e) => {
+      const { name, value } = e.target;
+      if (name === 'loginId' || name === 'nickname') {
+        setForm(prev => ({
+          ...prev,
+          [name]: value.replace(/\s/g, '')
+        }));
+      } else {
+        setForm(prev => ({
+          ...prev,
+          [name]: value
+        }));
+      }
+
+      if (name === 'password') validatePassword(value);
+
+      if ((name === 'password' && form.confirmPassword !== '') ||
+          (name === 'confirmPassword' && form.password !== '')) {
+        const matched = value === (name === 'password' ? form.confirmPassword : form.password);
+        setIsPasswordMatched(matched);
+        setPasswordMatchMessage(matched ? t('signupPage.passwordValidation.match') : t('signupPage.passwordValidation.mismatch'));
+      } else {
+        setIsPasswordMatched(null);
+        setPasswordMatchMessage('');
+      }
+
+      if (name === 'loginId') setIsIdChecked(null);
+      if (name === 'email') {
+        setIsEmailChecked(false);
+        setIsEmailVerified(false);
+      }
+      if (name === 'nickname') setIsNicknameChecked(null);
+    };
+  
+    const handleIdCheck = async () => {
+      if (!form.loginId.trim()) {
+        alert(t('signupPage.errorEmpty.id'));
+        return;
+      }
+      if (form.loginId.includes(' ')) {
+        alert(t('signupPage.errorInvalid.id'));
+        return;
+      }
+
+      try {
+        const result = await checkLoginId(form.loginId);
+        if (result) {
+          setIsIdChecked(true);
+          setIdCheckMessage(t('signupPage.success.id'));
+        } else {
+          setIsIdChecked(false);
+          setIdCheckMessage(t('signupPage.errorDuplicate.id'));
+        }
+      } catch (error) {
+        console.error('ID check error:', error);
+        setIdCheckMessage(error.message || t('errorServer'));
+        setIsIdChecked(false);
+      }
+    };
+  
+    const handleEmailCheck = async () => {
+      if (!form.email.trim()) {
+        alert(t('signupPage.errorEmpty.email'));
+        return;
+      }
+
+      const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
+      if (!emailRegex.test(form.email)) {
+        alert(t('signupPage.errorInvalid.email'));
+        return;
+      }
+
+      try {
+        const result = await checkEmail(form.email);
+        if (result) {
+          setIsEmailChecked(true);
+          setEmailCheckMessage(t('signupPage.success.email'));
+        } else {
+          setIsEmailChecked(false);
+          setEmailCheckMessage(t('signupPage.errorDuplicate.email'));
+        }
+      } catch (error) {
+        console.error('Email check error:', error);
+        setEmailCheckMessage(error.message || t('errorServer'));
+        setIsEmailChecked(false);
+      }
+    };
+  
+    const handleSendVerificationCode = async () => {
+        const success = await sendEmailCode(form.email);
+        if (success) {
+          alert(t('signupPage.verification.sendSuccess'));
+          setShowVerificationModal(true);
+        } else {
+          alert(t('signupPage.verification.sendError'));
+        }
+      };     
+  
+    const handleVerifyCode = async () => {
+      try {
+        const verified = await verifyEmailCode(form.email, verificationCode);
+        if (verified) {
+          setIsEmailVerified(true);
+          setShowVerificationModal(false);
+          setVerifyMessage(t('signupPage.success.emailVerification'));
+          setEmailCheckMessage(t('signupPage.success.emailVerification'));
+        } else {
+          setVerifyMessage(t('signupPage.verification.invalidCode'));
+          setIsEmailVerified(false);
+        }
+      } catch (error) {
+        console.error('Verification error:', error);
+        setVerifyMessage(t('signupPage.verification.error'));
+        setIsEmailVerified(false);
+      }
+    };
+  
+    const handleNicknameCheck = async () => {
+      if (!form.nickname.trim()) {
+        alert(t('signupPage.errorEmpty.nickname'));
+        return;
+      }
+      if (form.nickname.includes(' ')) {
+        alert(t('signupPage.errorInvalid.nickname'));
+        return;
+      }
+
+      try {
+        const result = await checkNickname(form.nickname);
+        if (result) {
+          setIsNicknameChecked(true);
+          setNicknameCheckMessage(t('signupPage.success.nickname'));
+        } else {
+          setIsNicknameChecked(false);
+          setNicknameCheckMessage(t('signupPage.errorDuplicate.nickname'));
+        }
+      } catch (error) {
+        console.error('Nickname check error:', error);
+        setNicknameCheckMessage(error.message || t('errorServer'));
+        setIsNicknameChecked(false);
+      }
+    };
+  
+    const validatePassword = (pw) => {
+      const hasEnglish = /[a-zA-Z]/.test(pw);
+      const hasUpper = /[A-Z]/.test(pw);
+      const hasNumber = /\d/.test(pw);
+      const hasSpecial = /[!@^*]/.test(pw);
+      const isProperLength = pw.length >= 8 && pw.length <= 20;
+      const hasNoSpace = !/\s/.test(pw);
+      const hasNoKorean = !/[ㄱ-ㅎ가-힣]/.test(pw);
+  
+      const isValid = hasEnglish && hasUpper && hasNumber && hasSpecial && isProperLength && hasNoSpace && hasNoKorean;
+      setIsPasswordValid(isValid);
+      setPasswordValidMessage(isValid ? t('signupPage.passwordValidation.valid') : t('signupPage.passwordValidation.invalid'));
+    };
+    
+    const handleSubmit = async (e) => {
+      e.preventDefault();
+
+      const missingItems = [];
+      if (!isIdChecked) missingItems.push(t('signupPage.submit.idCheck'));
+      if (!isEmailChecked) missingItems.push(t('signupPage.submit.emailCheck'));
+      if (!isEmailVerified) missingItems.push(t('signupPage.submit.emailVerification'));
+      if (!isPasswordValid) missingItems.push(t('signupPage.submit.passwordCheck'));
+      if (!isPasswordMatched) missingItems.push(t('signupPage.submit.passwordMatch'));
+      if (!isNicknameChecked) missingItems.push(t('signupPage.submit.nicknameCheck'));
+
+      if (missingItems.length > 0) {
+        alert(`${t('signupPage.submit.missingItems')}\n\n${missingItems.join('\n')}`);
+        return;
+      }
+
+      try {
+        await signupUser({
+          loginId: form.loginId,
+          password: form.password,
+          email: form.email,
+          nickname: form.nickname
+        });
+        
+        alert(t('signupPage.submit.success'));
+        navigate('/signup-complete');
+      } catch (err) {
+        console.error('Signup submission error:', err);
+        if (err instanceof Error) {
+          alert(err.message);
+        } else {
+          alert(t('signupPage.submit.error'));
+        }
+      }
+    };
+
+  return (
+    <div className="w-2/5 min-w-[400px] max-w-[700px] mx-auto my-12">
+      <div className="w-full bg-white rounded-2xl shadow-xl p-12">
+        <h2 className="text-4xl font-bold text-center mb-8 border-b pb-6">{t('signupPage.title')}</h2>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* 아이디 */}
+          <div className="h-[85px]">
+            <label className="font-bold text-lg">{t('signupPage.id')}</label>
+            <div className="flex justify-between items-center border-b border-gray-300">
+              <input
+                type="text"
+                name="loginId"
+                placeholder={t('signupPage.idPlaceholder')}
+                value={form.loginId}
+                onChange={(e) => {
+                  handleChange(e);
+                  setIsIdChecked(null);
+                  setIdCheckMessage('');
+                }}
+                className="w-full py-3 text-lg focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={handleIdCheck}
+                className="text-base text-gray-500 whitespace-nowrap ml-2 hover:text-blue-600"
+              >
+                {t('signupPage.checkDuplicate')}
+              </button>
+            </div>
+            {idCheckMessage && (
+              <p className={`text-sm mt-1 ${isIdChecked ? 'text-green-600' : 'text-red-500'}`}>
+                {idCheckMessage}
+              </p>
+            )}
+          </div>
+
+          {/* 이메일 */}
+          <div className="h-[85px]">
+            <label className="font-bold text-lg">{t('signupPage.email')}</label>
+            <div className="flex justify-between items-center border-b border-gray-300">
+              <input
+                type="email"
+                name="email"
+                value={form.email}
+                onChange={(e) => {
+                  handleChange(e);
+                  setIsEmailChecked(false);
+                  setEmailCheckMessage('');
+                }}
+                placeholder={t('signupPage.emailPlaceholder')}
+                className="w-full py-3 text-lg focus:outline-none"
+              />
+              {!isEmailChecked ? (
+                <button
+                  type="button"
+                  onClick={handleEmailCheck}
+                  className="text-base text-gray-500 whitespace-nowrap ml-2 hover:text-blue-600"
+                >
+                  {t('signupPage.checkDuplicate')}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleSendVerificationCode}
+                  className="text-base text-blue-600 whitespace-nowrap ml-2 hover:underline"
+                >
+                  {t('signupPage.getVerificationCode')}
+                </button>
+              )}
+            </div>
+            {emailCheckMessage && (
+              <p className={`text-sm mt-1 ${isEmailChecked ? 'text-green-600' : 'text-red-500'}`}>
+                {emailCheckMessage}
+              </p>
+            )}
+          </div>
+
+          {showVerificationModal && (
+            <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+                <div className="bg-white p-8 rounded-lg shadow-lg w-96">
+                <h3 className="text-xl font-bold mb-4">{t('signupPage.verifyEmail')}</h3>
+                <p className="mb-2">{t('signupPage.verifyEmailDesc')}</p>
+                <input
+                    type="text"
+                    placeholder={t('signupPage.verificationCodePlaceholder')}
+                    value={verificationCode}
+                    onChange={(e) => setVerificationCode(e.target.value)}
+                    className="w-full border px-3 py-2 mb-4"
+                />
+                {verifyMessage && <p className="text-sm text-red-500 mb-2">{verifyMessage}</p>}
+                <div className="flex justify-end gap-2">
+                    <button onClick={() => setShowVerificationModal(false)} className="px-4 py-2 text-gray-600 hover:underline">
+                    {t('signupPage.cancel')}
+                    </button>
+                    <button onClick={handleVerifyCode} className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                    {t('signupPage.confirm')}
+                    </button>
+                </div>
+                </div>
+            </div>
+          )}
+
+          {/* 비밀번호 */}
+          <div className="h-[85px]">
+            <label className="font-bold text-lg">{t('signupPage.password')}</label>
+            <div className="border-b border-gray-300">
+              <input
+                type="password"
+                name="password"
+                placeholder={t('signupPage.passwordPlaceholder')}
+                value={form.password}
+                onChange={handleChange}
+                className="w-full py-3 text-lg focus:outline-none"
+              />
+            </div>
+          </div>
+
+          {/* 비밀번호 확인 */}
+          <div className="h-[85px]">
+            <label className="font-bold text-lg">{t('signupPage.confirmPassword')}</label>
+            <div className="border-b border-gray-300">
+              <input
+                type="password"
+                name="confirmPassword"
+                placeholder={t('signupPage.confirmPasswordPlaceholder')}
+                value={form.confirmPassword}
+                onChange={handleChange}
+                className="w-full py-3 text-lg focus:outline-none"
+              />
+            </div>
+            {passwordMatchMessage && (
+              <p className={`text-sm mt-1 ${isPasswordMatched ? 'text-green-600' : 'text-red-500'}`}>
+                {passwordMatchMessage}
+              </p>
+            )}
+          </div>
+
+          {passwordValidMessage && (
+            <p className={`text-sm mt-1 ${isPasswordValid ? 'text-green-600' : 'text-red-500'}`}>
+                {passwordValidMessage}
+            </p>
+          )}
+
+          {/* 닉네임 */}
+          <div className="h-[85px]">
+            <label className="font-bold text-lg">{t('signupPage.nickname')}</label>
+            <div className="flex justify-between items-center border-b border-gray-300">
+              <input
+                type="text"
+                name="nickname"
+                value={form.nickname}
+                onChange={(e) => {
+                  handleChange(e);
+                  setIsNicknameChecked(null);
+                  setNicknameCheckMessage('');
+                }}
+                placeholder={t('signupPage.nicknamePlaceholder')}
+                className="w-full py-3 text-lg focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={handleNicknameCheck}
+                className="text-base text-gray-500 whitespace-nowrap ml-2 hover:text-blue-600"
+              >
+                {t('signupPage.checkDuplicate')}
+              </button>
+            </div>
+            {nicknameCheckMessage && (
+              <p className={`text-sm mt-1 ${isNicknameChecked ? 'text-green-600' : 'text-red-500'}`}>
+                {nicknameCheckMessage}
+              </p>
+            )}
+          </div>
+
+          {/* 가입 버튼 */}
+          <div className="pt-4">
+            <button
+              type="submit"
+              className="w-full py-4 rounded-md font-semibold text-lg bg-gray-800 text-white hover:bg-gray-700"
+            >
+              {t('signupPage.signupButton')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d5c6eabc-ca8c-4350-a333-96f6241761e9)

### 1. 회원가입 페이지 구현

- 회원가입 작동
- 닉네임, 이메일, 아이디 중복 체크 작동
- 비밀번호 조건 완료 (8~20자, 영문(대문자 포함) + 숫자 + 특수문자(!@^*)를 포함해야 하며 공백/한글은 사용할 수 없습니다.)

![image](https://github.com/user-attachments/assets/742eaf90-32ea-40ad-9e20-2ee9c1007eba)

- 이메일 인증 API 작동 확인 

![image](https://github.com/user-attachments/assets/c1d47a41-a645-49d8-bd61-04f14a64896e)

- 회원가입 완료 후 DB 저장 확인 

![image](https://github.com/user-attachments/assets/598ff53d-c6e9-488c-a756-62d7be7a8952)

- i18n 작동 확인 

### 2. 비밀번호 초기화 코드 개선

![image](https://github.com/user-attachments/assets/137e1855-d738-48a1-b93b-bd9d549d2861)

- 비밀번호 초기화 작동 조건 강화
- 아직 백에 API 미구현으로 작동 확인은 추후 예정

![image](https://github.com/user-attachments/assets/4ada5e5b-e936-44d5-b598-101a00e35322)

### 3. 로그인 기능 확인

![image](https://github.com/user-attachments/assets/82a9713f-e990-4b63-a508-24b410ff481c)

- 로그인 완료 시 헤더 변경 및 홈페이지로 이동 
- 로그아웃 시 헤더 변경 및 로그인 페이지로 이동 